### PR TITLE
fix: AWS parsing env vars as string, forcing int

### DIFF
--- a/lambda/autoscale/autoscale.py
+++ b/lambda/autoscale/autoscale.py
@@ -93,7 +93,7 @@ def update_record(zone_id, ip, hostname, operation):
                     'ResourceRecordSet': {
                         'Name': hostname,
                         'Type': 'A',
-                        'TTL': os.environ['ROUTE53_TTL'],
+                        'TTL': int(os.environ['ROUTE53_TTL']),
                         'ResourceRecords': [{'Value': ip}]
                     }
                 }


### PR DESCRIPTION
Cherry pick from https://github.com/meltwater/terraform-aws-asg-dns-handler/pull/59