### PR TITLE
Allow to build the lambda using an external image instead of the provided lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,12 +106,13 @@ data "archive_file" "autoscale" {
 resource "aws_lambda_function" "autoscale_handling" {
   depends_on = [aws_sns_topic.autoscale_handling]
 
-  filename         = data.archive_file.autoscale.output_path
+  filename         = var.lambda_image_uri != null ? null : data.archive_file.autoscale.output_path
   function_name    = "${var.vpc_name}-${var.autoscale_handler_unique_identifier}"
   role             = aws_iam_role.autoscale_handling.arn
-  handler          = "autoscale.lambda_handler"
-  runtime          = "python3.8"
-  source_code_hash = filebase64sha256(data.archive_file.autoscale.output_path)
+  handler          = var.lambda_image_uri != null ? null : "autoscale.lambda_handler"
+  runtime          = var.lambda_image_uri != null ? null : "python3.8"
+  source_code_hash = var.lambda_image_uri != null ? null : filebase64sha256(data.archive_file.autoscale.output_path)
+  image_uri        = var.lambda_image_uri != null ? var.lambda_image_uri : null
   description      = "Handles DNS for autoscaling groups by receiving autoscaling notifications and setting/deleting records from route53"
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,9 @@ variable "route53_record_ttl" {
   default     = 300
   type        = number
 }
+
+variable "lambda_image_uri" {
+  default     = null
+  type        = string
+  description = "The URI of the Lambda image"
+}


### PR DESCRIPTION
This PR:

- Allows to build the lambda using an external image instead of the provided lambda
- Addresses https://github.com/meltwater/terraform-aws-asg-dns-handler/issues/61